### PR TITLE
fix: Black CI

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -8,7 +8,7 @@ defaults:
 
 on:
   pull_request:
-    branches: [master, dev]
+    branches: [main, dev]
 
 jobs:
   build:


### PR DESCRIPTION
Currently the github action is not being run on new PR because it is referencing `master` branch instead of `main` branch.