### PR TITLE
fix: EOF error when parsing cairo files

### DIFF
--- a/amarna/amarna.py
+++ b/amarna/amarna.py
@@ -126,7 +126,7 @@ class Amarna:
         """
         try:
             with open(filename, "r", encoding="utf8") as f:
-                return self.parser.parse(f.read(), start="cairo_file")
+                return self.parser.parse(f.read() + "\n", start="cairo_file")
         except exceptions.UnexpectedCharacters as e:
             print(f"Could not parse {filename}: {e}")
             return None

--- a/amarna/amarna.py
+++ b/amarna/amarna.py
@@ -126,6 +126,7 @@ class Amarna:
         """
         try:
             with open(filename, "r", encoding="utf8") as f:
+                # the cairo grammar requires a newline at the end
                 return self.parser.parse(f.read() + "\n", start="cairo_file")
         except exceptions.UnexpectedCharacters as e:
             print(f"Could not parse {filename}: {e}")


### PR DESCRIPTION
**Description**
- Adds a newline at the end of every read cairo file. 

**Metadata**
- Fixes #20 
