### PR TITLE
Add dataclasses for function calls and callbacks.

### DIFF
--- a/amarna/rules/gatherer_rules/AllFunctionCallsGatherer.py
+++ b/amarna/rules/gatherer_rules/AllFunctionCallsGatherer.py
@@ -1,9 +1,19 @@
-from typing import Tuple, Any, List
+from typing import List, Union
+from dataclasses import dataclass
 
 from lark import tree
+from amarna.Result import PositionType, getPosition
 from amarna.rules.GenericGatherer import GenericGatherer
 
-FunctionCallType = Tuple[str, str, Any]
+
+@dataclass
+class FunctionCallType:
+    """Represents a function call."""
+
+    file_name: str
+    function_name: str
+    position: PositionType
+    arguments: Union[str, tree.Tree]
 
 
 class AllFunctionCallsGatherer(GenericGatherer[list]):
@@ -26,6 +36,5 @@ class AllFunctionCallsGatherer(GenericGatherer[list]):
         function_name: str = func_id.children[0].value  # type: ignore
         arguments = func.children[-1]
 
-        tup: Tuple[str, str, Any] = (self.fname, function_name, arguments)
-
-        self.function_calls.append(tup)
+        function_call = FunctionCallType(self.fname, function_name, getPosition(func), arguments)
+        self.function_calls.append(function_call)

--- a/amarna/rules/gatherer_rules/FunctionsUsedAsCallbacksGatherer.py
+++ b/amarna/rules/gatherer_rules/FunctionsUsedAsCallbacksGatherer.py
@@ -1,22 +1,33 @@
-from typing import Tuple, List
+from dataclasses import dataclass
+from typing import List
 
 from lark import Tree
+from amarna.Result import PositionType, getPosition
 
 from amarna.rules.GenericGatherer import GenericGatherer
 
 
+@dataclass
+class CallbackFunctionType:
+    """Represents a function callback."""
+
+    file_name: str
+    function_name: str
+    position: PositionType
+
+
 class FunctionsUsedAsCallbacksGatherer(GenericGatherer):
     """
-    Gather all function that are used as callbacks.
+    Gather all functions that are used as callbacks.
     """
 
     GATHERER_NAME = "FunctionsUsedAsCallbacks"
 
     def __init__(self) -> None:
         super().__init__()
-        self.function_calls: List[Tuple[str, str]] = []
+        self.function_calls: List[CallbackFunctionType] = []
 
-    def get_gathered_data(self) -> List[Tuple[str, str]]:
+    def get_gathered_data(self) -> List[CallbackFunctionType]:
         return self.function_calls
 
     def function_call(self, tree: Tree) -> None:
@@ -49,6 +60,6 @@ class FunctionsUsedAsCallbacksGatherer(GenericGatherer):
         elif function_name == "get_label_location":
             for identifier in tree.find_data("atom_identifier"):
                 token = identifier.children[0].children[0]
-                tup = (self.fname, str(token))
 
-                self.function_calls.append(tup)
+                callback = CallbackFunctionType(self.fname, str(token), getPosition(token))
+                self.function_calls.append(callback)

--- a/amarna/rules/post_process_rules/UnusedFunctionsRule.py
+++ b/amarna/rules/post_process_rules/UnusedFunctionsRule.py
@@ -5,8 +5,12 @@ from amarna.rules.gatherer_rules.DeclaredFunctionsGatherer import (
     DeclaredFunctionsGatherer,
     FunctionType,
 )
-from amarna.rules.gatherer_rules.AllFunctionCallsGatherer import AllFunctionCallsGatherer
+from amarna.rules.gatherer_rules.AllFunctionCallsGatherer import (
+    AllFunctionCallsGatherer,
+    FunctionCallType,
+)
 from amarna.rules.gatherer_rules.FunctionsUsedAsCallbacksGatherer import (
+    CallbackFunctionType,
     FunctionsUsedAsCallbacksGatherer,
 )
 from amarna.rules.gatherer_rules.ImportGatherer import ImportGatherer, ImportType
@@ -27,9 +31,13 @@ class UnusedFunctionsRule:
         declared_functions: List[FunctionType] = gathered_data[
             DeclaredFunctionsGatherer.GATHERER_NAME
         ]
-        function_calls = gathered_data[AllFunctionCallsGatherer.GATHERER_NAME]
+        function_calls: List[FunctionCallType] = gathered_data[
+            AllFunctionCallsGatherer.GATHERER_NAME
+        ]
 
-        callbacks = gathered_data[FunctionsUsedAsCallbacksGatherer.GATHERER_NAME]
+        callbacks: List[CallbackFunctionType] = gathered_data[
+            FunctionsUsedAsCallbacksGatherer.GATHERER_NAME
+        ]
 
         import_stmts: List[ImportType] = gathered_data[ImportGatherer.GATHERER_NAME]
 
@@ -37,12 +45,10 @@ class UnusedFunctionsRule:
 
         all_called = []
         for call in function_calls:
-            _, function_name, _ = call
-            all_called.append(function_name)
+            all_called.append(call.function_name)
 
         for call in callbacks:
-            _, function_name = call
-            all_called.append(function_name)
+            all_called.append(call.function_name)
 
         # replace with actual function name if alias
         for imp in import_stmts:

--- a/tests/expected/import_aliasing_test.expected
+++ b/tests/expected/import_aliasing_test.expected
@@ -1,2 +1,2 @@
-[unused-function] in library.cairo:4:1
 [unused-function] in main.cairo:3:1
+[unused-function] in library.cairo:4:1


### PR DESCRIPTION
**Pull request description**

Add dataclasses for FunctionCallType and CallbackFunctionType, removing the tuple pattern with unnamed fields.
