### PR TITLE
Warn on uninitialized variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Amarna is a static-analyzer and linter for the Cairo programming language.
 | 11  | Storage variable collision  | Multiple `@storage_var` with the same name.                                                                               | Warning | High      |
 | 12  | Implicit function import    | Function with decorator `@external, @view, @l1_handler` that is being implicitly imported.                                | Info    | High      |
 | 13  | Unenforced view function    | State modification within a `@view` function                                                                              | Info    | High      |
+| 14  | Uninitialized variable      | Local variables that are never initialized.                                                                               | Info    | High      |
 
 
 ## Usage

--- a/amarna/rules/local_rules/UninitializedVariableRule.py
+++ b/amarna/rules/local_rules/UninitializedVariableRule.py
@@ -28,10 +28,16 @@ class UninitializedVariableRule(GenericRule):
             for child in let_reference.children[0].find_data("identifier_def"):
                 assigned_variables.add(child.children[0])
 
-        # ignore if they are expressed in a inst_assert_eq
+        # ignore if they are expressed in a inst_assert_eq used as assignment
         for a in tree.find_data("inst_assert_eq"):
             for children_id in a.children[0].find_data("identifier"):
                 assigned_variables.add(children_id.children[0])
+
+        # ignore if they are expressed in a assert used as assignment
+        for a in tree.find_data("code_element_compound_assert_eq"):
+            for b in a.children:
+                if b.data == "atom_identifier":
+                    assigned_variables.add(b.children[0].children[0])
 
         uninitialized_locals = local_variables - assigned_variables
         if not uninitialized_locals:

--- a/amarna/rules/local_rules/UninitializedVariableRule.py
+++ b/amarna/rules/local_rules/UninitializedVariableRule.py
@@ -1,3 +1,4 @@
+import re
 from typing import Set
 
 from lark import Tree, Token
@@ -51,7 +52,7 @@ class UninitializedVariableRule(GenericRule):
         # for now just ignore if they're in a hint
         used_in_hints = set()
         for uninitialized in uninitialized_locals:
-            if uninitialized.value in all_hints:
+            if re.search("ids\." + uninitialized.value + "( |,|\.).*=", all_hints):
                 used_in_hints.add(uninitialized)
 
         uninitialized_locals = uninitialized_locals - used_in_hints

--- a/amarna/rules/local_rules/UninitializedVariableRule.py
+++ b/amarna/rules/local_rules/UninitializedVariableRule.py
@@ -1,0 +1,60 @@
+from typing import Set
+
+from lark import Tree, Token
+from amarna.rules.GenericRule import GenericRule
+from amarna.Result import create_result_token
+
+
+class UninitializedVariableRule(GenericRule):
+    """
+    Check for uninitialized local variables.
+    """
+
+    RULE_TEXT = "This local variable is uninitialized and never assigned."
+    RULE_NAME = "uninitialized-variable"
+
+    def code_element_function(self, tree: Tree) -> None:
+        local_variables: Set[Token] = set()
+        assigned_variables: Set[Token] = set()
+
+        for local_declaration in tree.find_data("code_element_local_var"):
+            # only gather unintialized locals
+            if len(local_declaration.children) == 1:
+                for child in local_declaration.children[0].find_data("identifier_def"):
+                    local_variables.add(child.children[0])
+
+        # ignore if they are assigned
+        for let_reference in tree.find_data("code_element_reference"):
+            for child in let_reference.children[0].find_data("identifier_def"):
+                assigned_variables.add(child.children[0])
+
+        # ignore if they are expressed in a inst_assert_eq
+        for a in tree.find_data("inst_assert_eq"):
+            for children_id in a.children[0].find_data("identifier"):
+                assigned_variables.add(children_id.children[0])
+
+        uninitialized_locals = local_variables - assigned_variables
+        if not uninitialized_locals:
+            return
+
+        # gather all hint code and check if the variables are there
+        all_hints = ""
+        for hint in self.original_tree.find_data("code_element_hint"):
+            all_hints += hint.children[0]
+
+        # for now just ignore if they're in a hint
+        used_in_hints = set()
+        for uninitialized in uninitialized_locals:
+            if uninitialized.value in all_hints:
+                used_in_hints.add(uninitialized)
+
+        uninitialized_locals = uninitialized_locals - used_in_hints
+
+        for tok in uninitialized_locals:
+            result = create_result_token(
+                self.fname,
+                self.RULE_NAME,
+                self.RULE_TEXT,
+                tok,
+            )
+            self.results.append(result)

--- a/amarna/rules/local_rules_module.py
+++ b/amarna/rules/local_rules_module.py
@@ -9,3 +9,4 @@ from amarna.rules.local_rules.UnusedArgumentRule import UnusedArgumentRule
 from amarna.rules.local_rules.UnknownDecoratorRule import UnknownDecoratorRule
 from amarna.rules.local_rules.UnusedImportRule import UnusedImportRule
 from amarna.rules.local_rules.DeadStoreRule import DeadStoreRule
+from amarna.rules.local_rules.UninitializedVariableRule import UninitializedVariableRule

--- a/tests/expected/dead_store.expected
+++ b/tests/expected/dead_store.expected
@@ -1,3 +1,4 @@
 [dead-store] in dead_store.cairo:17:5
 [dead-store] in dead_store.cairo:3:11
+[uninitialized-variable] in dead_store.cairo:3:11
 [unused-function] in dead_store.cairo:1:1

--- a/tests/expected/uninitialized_variable.expected
+++ b/tests/expected/uninitialized_variable.expected
@@ -1,4 +1,5 @@
-[arithmetic-mul] in uninitialized_variable.cairo:7:12
+[arithmetic-mul] in uninitialized_variable.cairo:11:12
+[dead-store] in uninitialized_variable.cairo:10:5
 [dead-store] in uninitialized_variable.cairo:4:11
 [dead-store] in uninitialized_variable.cairo:5:11
 [uninitialized-variable] in uninitialized_variable.cairo:3:11

--- a/tests/expected/uninitialized_variable.expected
+++ b/tests/expected/uninitialized_variable.expected
@@ -1,0 +1,5 @@
+[arithmetic-mul] in uninitialized_variable.cairo:7:12
+[dead-store] in uninitialized_variable.cairo:4:11
+[dead-store] in uninitialized_variable.cairo:5:11
+[uninitialized-variable] in uninitialized_variable.cairo:3:11
+[unused-function] in uninitialized_variable.cairo:1:1

--- a/tests/expected/uninitialized_variable2.expected
+++ b/tests/expected/uninitialized_variable2.expected
@@ -1,0 +1,3 @@
+[dead-store] in uninitialized_variable2.cairo:4:11
+[uninitialized-variable] in uninitialized_variable2.cairo:3:11
+[unused-function] in uninitialized_variable2.cairo:1:1

--- a/tests/uninitialized_variable.cairo
+++ b/tests/uninitialized_variable.cairo
@@ -1,0 +1,9 @@
+func bar() -> (res):
+    alloc_locals
+    local x
+    local y = 2
+    local z
+    let z = 1
+    assert x * x = 25
+    return (res=x)
+end

--- a/tests/uninitialized_variable.cairo
+++ b/tests/uninitialized_variable.cairo
@@ -4,6 +4,10 @@ func bar() -> (res):
     local y = 2
     local z
     let z = 1
+    local b
+    assert b = 2
+    local a
+    a = 3
     assert x * x = 25
     return (res=x)
 end

--- a/tests/uninitialized_variable2.cairo
+++ b/tests/uninitialized_variable2.cairo
@@ -1,0 +1,9 @@
+func bar() -> (res):
+    alloc_locals
+    local x
+    local xx
+    %{
+    ids.xx = 3
+    %}
+    return (res=x)
+end


### PR DESCRIPTION
**Creating a new rule**
- [x] Documented the code.
- [x] Added tests for the new rule in the `amarna/tests/` folder.
- [x] Added the new rule description to the README file.

**Pull request description**
- Added a rule to warn on uninitialized variables ie [local variables](https://www.cairo-lang.org/docs/how_cairo_works/consts.html#local-variables) that are not declared to an expression and subsequently never [referenced](https://www.cairo-lang.org/docs/how_cairo_works/consts.html#references).
- For now also ignores if the variable appear in a hint or a part of the assert equal instruction(`inst_assert_eq`).
<!--
Explain what this PR does.
If adding a new rule explain the new rule.
If fixing an issue, provide details.
-->
<!--
Write "closes #XX" in the comment to auto-close issue #XX when the PR is merged.
-->
