### PR TITLE
fix: deadstore FP where use happens after first return statement

### DIFF
--- a/tests/dead_store3.cairo
+++ b/tests/dead_store3.cairo
@@ -1,0 +1,9 @@
+func are_equal(x, y) -> (eq):
+    let (a) = 44
+    if x == y:
+        return (FALSE)
+    end
+    if x == a:
+        return (TRUE)
+    end
+end

--- a/tests/expected/dead_store3.expected
+++ b/tests/expected/dead_store3.expected
@@ -1,0 +1,1 @@
+[unused-function] in dead_store3.cairo:1:1


### PR DESCRIPTION
**Pull request description**
- Fixes FP in dead-store where a defined variable is used after the first return statement.
<!--
Explain what this PR does.
If adding a new rule explain the new rule.
If fixing an issue, provide details.
-->

**Fixes issues**
- closes #71 
<!--
Write "closes #XX" in the comment to auto-close issue #XX when the PR is merged.
-->
