### PR TITLE
Add rule deprecation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Analyze a single file `file.cairo` and print a summary of the results:
 | 8   | Dead stores                 | Variables that are assigned values but not used before a return statement                                                 | Info    | Medium    |
 | 9   | Unchecked overflows         | Function calls that ignore the returned overflow flags, e.g., `uint256_add`                                               | Warning | High      |
 | 10  | Caller address return value | Function calls to the `get_caller_address` function.                                                                      | Info    | High      |
-| 11  | Storage variable collision  | Multiple `@storage_var` with the same name.                                                                               | Warning | High      |
-| 12  | Implicit function import    | Function with decorator `@external, @view, @l1_handler` that is being implicitly imported.                                | Info    | High      |
+| 11  | Storage variable collision  | Multiple `@storage_var` with the same name. (deprecated)                                                                  | Warning | High      |
+| 12  | Implicit function import    | Function with decorator `@external, @view, @l1_handler` that is being implicitly imported. (deprecated)                   | Info    | High      |
 | 13  | Unenforced view function    | State modification within a `@view` function                                                                              | Info    | High      |
 | 14  | Uninitialized variable      | Local variables that are never initialized.                                                                               | Info    | High      |
 

--- a/amarna/command_line.py
+++ b/amarna/command_line.py
@@ -26,6 +26,8 @@ Analyze a Cairo file using all rules except the arithmetic-add rule:
  amarna file.cairo --except-rules=arithmetic-add
  """
 
+DEPRECATED_RULES = ["storage-var-collision", "implicit-import"]
+
 
 def parse_comma_sep_strings(s: str) -> List[str]:
     if s:
@@ -48,7 +50,7 @@ def get_rule_names(rule_str: str, excluded_str: str) -> List[str]:
     if rules:
         base_rules = rules
     else:
-        base_rules = ALL_RULES
+        base_rules = [rule for rule in ALL_RULES if rule not in DEPRECATED_RULES]
 
     return [rule for rule in base_rules if rule not in excluded]
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     name="amarna",
-    version="0.1.4",
+    version="0.1.5",
     description="Amarna is a static-analyzer for the Cairo programming language.",
     url="https://github.com/crytic/amarna",
     author="Trail of Bits",


### PR DESCRIPTION
The implicit import and storage variable collision vulnerabilities are no longer vulnerabilities in Cairo.